### PR TITLE
Feat: 경매 등록 기능 및 NCP Storage 버킷에 사진 업로드 연동 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.261'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/jungmae/auction/controller/AuctionController.java
+++ b/src/main/java/jungmae/auction/controller/AuctionController.java
@@ -1,42 +1,105 @@
 package jungmae.auction.controller;
 
 
+
 import jakarta.servlet.http.HttpServletRequest;
-import jungmae.auction.domain.dto.AuctionDto;
-import jungmae.auction.repository.AuctionRepository;
+import jungmae.auction.domain.dto.*;
 import jungmae.auction.service.AuctionService;
+import jungmae.auction.service.ImageService;
+import jungmae.auction.service.NaverCloudS3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 public class AuctionController {
 
     private final AuctionService auctionService;
-    private final AuctionRepository auctionRepository;
+    private final NaverCloudS3Service naverCloudS3Service;
+    private final ImageService imageService;
+
+    @GetMapping("/api/image")
+    public ResponseEntity<?> transImageToByte(@RequestBody ImagePathDto imagePathDto) {
+
+        ImageByteDto byteImageDto = null;
+
+        try {
+            byte[][] imageBytes = new byte[imagePathDto.getImagePaths().length][];
+            for (int i = 0; i < imagePathDto.getImagePaths().length; i++) {
+                Path path = Paths.get(imagePathDto.getImagePaths()[i]);
+                imageBytes[i] = Files.readAllBytes(path);
+                System.out.println(i + "번째 이미지의 바이트 길이 : " + imageBytes[i].length);
+            }
+            byteImageDto = new ImageByteDto(imageBytes);
+            return new ResponseEntity<>(byteImageDto, HttpStatus.OK);
+        } catch (IOException e1) {
+            e1.printStackTrace();
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+
+    }
 
     @PostMapping("/api/auction")
-    public ResponseEntity<?> createAuction(@RequestBody AuctionDto auctionDto) {
-        System.out.println("경매 생성 컨트롤러 진앱");
+    public ResponseEntity<?> createAuction(@RequestBody AuctionByteImageDto auctionByteImageDto) {
+        System.out.println("경매 생성 컨트롤러 진입");
+        List<String> urls = new ArrayList<>();
+        AuctionImageUrlDto auctionImageUrlDto;
 
-        auctionService.createAuction(auctionDto);
+        // 이미지가 오지 않았을때 예외처리
+        if (auctionByteImageDto.getImages() == null || auctionByteImageDto.getImages().length == 0) {
+            return new ResponseEntity<>("이미지 정보가 없습니다.",HttpStatus.BAD_REQUEST);
+        }
 
-        return new ResponseEntity<>("경매 등록 성공!", HttpStatus.OK);
+        // 이미지 업로드 오류 및 서버오류처리
+        try {
+            // 경매 등록 데이터를 경매 DB에 저장.
+            AuctionNonImageDto auctionNonImageDto = auctionService.createAuction(auctionByteImageDto);
+            // NCP에 이미지 업로드 후 이미지의 저정 주소 URL값들을 받아옴.
+            urls = naverCloudS3Service.uploadImages(auctionByteImageDto.getImages());
+            System.out.println("urls 첫번째 = " + urls.get(0));
+            // 이미지 테이블에 이미지 URL 저장
+            imageService.saveAllImages(auctionNonImageDto, urls);
+
+            return new ResponseEntity<>("경매 등록 성공!", HttpStatus.OK);
+        } catch (IOException e) {
+            System.out.println("경매 등록 실패");
+            return new ResponseEntity<>("경매 등록 실패!!", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
     }
 
     @GetMapping("api/auction/{id}")
-    public ResponseEntity<?> deleteAuction(@PathVariable Long id) {
+    public ResponseEntity<?> findAuction(@PathVariable Long id) {
 
         try {
-            AuctionDto auctionDto = new AuctionDto(auctionRepository.findById(id).get());
-
+            AuctionByteImageDto auctionDto = auctionService.findAuction(id);
             return new ResponseEntity<>(auctionDto, HttpStatus.OK);
-        } catch (NullPointerException e) {
-            System.out.println("id값이 유효하지 않음");
+        } catch (Exception e) {
+            System.out.println("id값이 유효하지 않거나 해당 경매 정보가 없습니다.");
             return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED);
         }
     }
 
+    // 스케줄링? 시간 타이머를 사용? 해결법 모색해봐야 할 것 같다.
+    @PostMapping("api/auction/{id}/close")
+    public ResponseEntity<?> closeAuction(@PathVariable Long id) {
+
+        try {
+            AuctionByteImageDto auctionDto = auctionService.closeUpdateAuction(id);
+            return new ResponseEntity<>("해당 경매 종료", HttpStatus.OK);
+        } catch (Exception e) {
+            System.out.println("id값이 유효하지 않음");
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED);
+        }
+    }
 }

--- a/src/main/java/jungmae/auction/controller/AuctionController.java
+++ b/src/main/java/jungmae/auction/controller/AuctionController.java
@@ -3,19 +3,19 @@ package jungmae.auction.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jungmae.auction.domain.dto.AuctionDto;
+import jungmae.auction.repository.AuctionRepository;
 import jungmae.auction.service.AuctionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 public class AuctionController {
 
     private final AuctionService auctionService;
+    private final AuctionRepository auctionRepository;
 
     @PostMapping("/api/auction")
     public ResponseEntity<?> createAuction(@RequestBody AuctionDto auctionDto) {
@@ -24,6 +24,19 @@ public class AuctionController {
         auctionService.createAuction(auctionDto);
 
         return new ResponseEntity<>("경매 등록 성공!", HttpStatus.OK);
+    }
+
+    @GetMapping("api/auction/{id}")
+    public ResponseEntity<?> deleteAuction(@PathVariable Long id) {
+
+        try {
+            AuctionDto auctionDto = new AuctionDto(auctionRepository.findById(id).get());
+
+            return new ResponseEntity<>(auctionDto, HttpStatus.OK);
+        } catch (NullPointerException e) {
+            System.out.println("id값이 유효하지 않음");
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED);
+        }
     }
 
 }

--- a/src/main/java/jungmae/auction/domain/Auction.java
+++ b/src/main/java/jungmae/auction/domain/Auction.java
@@ -1,16 +1,16 @@
 package jungmae.auction.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import jungmae.auction.domain.dto.UserDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.sql.Array;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -27,12 +27,17 @@ public class Auction {
     private String description;
     private long quantity;
     private String startPrice;
-    private Timestamp createDate;
-    private Timestamp endDate;
+    private String createDate;
+    private String endDate;
     private long resisteredUserId;
     private long winningUserId;
     private String winningUserComment;
+    private String closedAuction;
 
+    @OneToMany(mappedBy = "auction", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Image> images;
 
-
+    public void updateClosedAuction(String str) {
+        closedAuction = str;
+    }
 }

--- a/src/main/java/jungmae/auction/domain/Auction.java
+++ b/src/main/java/jungmae/auction/domain/Auction.java
@@ -34,4 +34,5 @@ public class Auction {
     private String winningUserComment;
 
 
+
 }

--- a/src/main/java/jungmae/auction/domain/Image.java
+++ b/src/main/java/jungmae/auction/domain/Image.java
@@ -1,0 +1,29 @@
+package jungmae.auction.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String imageUrl;
+
+    @ManyToOne
+    @JoinColumn(name = "auction_id")    // 외래키 이름 설정.
+    private Auction auction;
+
+    public Image(String imageUrl, Auction auction) {
+        this.imageUrl = imageUrl;
+        this.auction = auction;
+    }
+}

--- a/src/main/java/jungmae/auction/domain/dto/AuctionByteImageDto.java
+++ b/src/main/java/jungmae/auction/domain/dto/AuctionByteImageDto.java
@@ -2,24 +2,26 @@ package jungmae.auction.domain.dto;
 
 import jungmae.auction.domain.Auction;
 import lombok.Data;
-
-import java.sql.Timestamp;
+import lombok.NoArgsConstructor;
 
 @Data
-public class AuctionDto {
+@NoArgsConstructor
+public class AuctionByteImageDto {
 
     private String title;
     private String name;
     private String description;
     private long quantity;
     private String startPrice;
-    private Timestamp createDate;
-    private Timestamp endDate;
+    private String createDate;
+    private String endDate;
     private long resisteredUserId;
     private long winningUserId;
     private String winningUserComment;
+    private String closedAuction;
+    private byte[][] images;
 
-    public AuctionDto(Auction auction) {
+    public AuctionByteImageDto(Auction auction) {
         this.title = auction.getTitle();
         this.name = auction.getName();
         this.description = auction.getDescription();
@@ -30,5 +32,6 @@ public class AuctionDto {
         this.resisteredUserId = auction.getResisteredUserId();
         this.winningUserId = auction.getWinningUserId();
         this.winningUserComment = auction.getWinningUserComment();
+        this.closedAuction = auction.getClosedAuction();
     }
 }

--- a/src/main/java/jungmae/auction/domain/dto/AuctionDto.java
+++ b/src/main/java/jungmae/auction/domain/dto/AuctionDto.java
@@ -1,5 +1,6 @@
 package jungmae.auction.domain.dto;
 
+import jungmae.auction.domain.Auction;
 import lombok.Data;
 
 import java.sql.Timestamp;
@@ -17,4 +18,17 @@ public class AuctionDto {
     private long resisteredUserId;
     private long winningUserId;
     private String winningUserComment;
+
+    public AuctionDto(Auction auction) {
+        this.title = auction.getTitle();
+        this.name = auction.getName();
+        this.description = auction.getDescription();
+        this.quantity = auction.getQuantity();
+        this.startPrice = auction.getStartPrice();
+        this.createDate = auction.getCreateDate();
+        this.endDate = auction.getEndDate();
+        this.resisteredUserId = auction.getResisteredUserId();
+        this.winningUserId = auction.getWinningUserId();
+        this.winningUserComment = auction.getWinningUserComment();
+    }
 }

--- a/src/main/java/jungmae/auction/domain/dto/AuctionImageUrlDto.java
+++ b/src/main/java/jungmae/auction/domain/dto/AuctionImageUrlDto.java
@@ -1,0 +1,58 @@
+package jungmae.auction.domain.dto;
+
+import jungmae.auction.domain.Auction;
+import jungmae.auction.domain.Image;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class AuctionImageUrlDto {
+
+    private String title;
+    private String name;
+    private String description;
+    private long quantity;
+    private String startPrice;
+    private String createDate;
+    private String endDate;
+    private long resisteredUserId;
+    private long winningUserId;
+    private String winningUserComment;
+    private String closedAuction;
+    private List<String> images;
+
+    public AuctionImageUrlDto(Auction auction) {
+        this.title = auction.getTitle();
+        this.name = auction.getName();
+        this.description = auction.getDescription();
+        this.quantity = auction.getQuantity();
+        this.startPrice = auction.getStartPrice();
+        this.createDate = auction.getCreateDate();
+        this.endDate = auction.getEndDate();
+        this.resisteredUserId = auction.getResisteredUserId();
+        this.winningUserId = auction.getWinningUserId();
+        this.winningUserComment = auction.getWinningUserComment();
+        this.closedAuction = auction.getClosedAuction();
+        this.images = auction.getImages()   // auction 객체에 연결된 image객체의 리스트 반환
+                .stream()   // 리스트를 스트림으로 변환하여 데이터 소스(배열, 리스트)에서 요소를 추출해 일련의 연산을 수행할 수 있도록 함.
+                .map(Image::getImageUrl)    // map을 통해 auction 객체의 image 객체 리스트에서 값을 추출해 스트림 형태로 변환.
+                .collect(Collectors.toList());  // collection으로 변환-> 그 중 List형태로 변환.
+    }
+    public AuctionImageUrlDto(AuctionNonImageDto auctionNonImageDto, List<String> urls) {
+        this.title = auctionNonImageDto.getTitle();
+        this.name = auctionNonImageDto.getName();
+        this.description = auctionNonImageDto.getDescription();
+        this.quantity = auctionNonImageDto.getQuantity();
+        this.startPrice = auctionNonImageDto.getStartPrice();
+        this.createDate = auctionNonImageDto.getCreateDate();
+        this.endDate = auctionNonImageDto.getEndDate();
+        this.resisteredUserId = auctionNonImageDto.getResisteredUserId();
+        this.closedAuction = auctionNonImageDto.getClosedAuction();
+        this.images = urls;  // auction 객체에 연결된 image객체의 리스트 반환
+
+    }
+
+}

--- a/src/main/java/jungmae/auction/domain/dto/AuctionNonImageDto.java
+++ b/src/main/java/jungmae/auction/domain/dto/AuctionNonImageDto.java
@@ -1,0 +1,47 @@
+package jungmae.auction.domain.dto;
+
+import jungmae.auction.domain.Auction;
+import lombok.Data;
+
+@Data
+public class AuctionNonImageDto {
+
+    private Long id;
+    private String title;
+    private String name;
+    private String description;
+    private long quantity;
+    private String startPrice;
+    private String createDate;
+    private String endDate;
+    private long resisteredUserId;
+    private String closedAuction;
+
+    public AuctionNonImageDto(Auction auction) {
+        this.id = auction.getId();
+        this.title = auction.getTitle();
+        this.name = auction.getName();
+        this.description = auction.getDescription();
+        this.quantity = auction.getQuantity();
+        this.startPrice = auction.getStartPrice();
+        this.createDate = auction.getCreateDate();
+        this.endDate = auction.getEndDate();
+        this.resisteredUserId = auction.getResisteredUserId();
+        this.closedAuction = auction.getClosedAuction();
+    }
+
+    public Auction toEntity() {
+        return Auction.builder()
+                .id(id)
+                .title(title)
+                .name(name)
+                .description(description)
+                .quantity(quantity)
+                .startPrice(startPrice)
+                .createDate(createDate)
+                .endDate(endDate)
+                .resisteredUserId(resisteredUserId)
+                .closedAuction(closedAuction)
+                .build();
+    }
+}

--- a/src/main/java/jungmae/auction/domain/dto/ImageByteDto.java
+++ b/src/main/java/jungmae/auction/domain/dto/ImageByteDto.java
@@ -1,0 +1,10 @@
+package jungmae.auction.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ImageByteDto {
+    private byte[][] images;
+}

--- a/src/main/java/jungmae/auction/domain/dto/ImagePathDto.java
+++ b/src/main/java/jungmae/auction/domain/dto/ImagePathDto.java
@@ -1,0 +1,9 @@
+package jungmae.auction.domain.dto;
+
+import lombok.Data;
+
+@Data
+public class ImagePathDto {
+
+    private String[] imagePaths;
+}

--- a/src/main/java/jungmae/auction/domain/dto/UserDto.java
+++ b/src/main/java/jungmae/auction/domain/dto/UserDto.java
@@ -1,6 +1,7 @@
 package jungmae.auction.domain.dto;
 
 import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.sql.Timestamp;
 
@@ -13,6 +14,7 @@ public class UserDto {
     private String role;
 
     private String provider;
+
     private Timestamp createDate;
 
 }

--- a/src/main/java/jungmae/auction/repository/ImageRepository.java
+++ b/src/main/java/jungmae/auction/repository/ImageRepository.java
@@ -1,0 +1,9 @@
+package jungmae.auction.repository;
+
+import jungmae.auction.domain.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+
+}

--- a/src/main/java/jungmae/auction/service/AuctionService.java
+++ b/src/main/java/jungmae/auction/service/AuctionService.java
@@ -1,11 +1,14 @@
 package jungmae.auction.service;
 
 import jungmae.auction.domain.Auction;
-import jungmae.auction.domain.dto.AuctionDto;
+import jungmae.auction.domain.dto.AuctionByteImageDto;
+import jungmae.auction.domain.dto.AuctionImageUrlDto;
+import jungmae.auction.domain.dto.AuctionNonImageDto;
 import jungmae.auction.repository.AuctionRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -13,32 +16,39 @@ public class AuctionService {
 
     private final AuctionRepository auctionRepository;
 
-    public void createAuction(AuctionDto auctionDto) {
 
-        Auction aution = Auction.builder()
-                .title(auctionDto.getTitle())
-                .name(auctionDto.getName())
-                .description(auctionDto.getDescription())
-                .quantity(auctionDto.getQuantity())
-                .startPrice(auctionDto.getStartPrice())
-                .createDate(auctionDto.getCreateDate())
-                .endDate(auctionDto.getEndDate())
-                .resisteredUserId(auctionDto.getResisteredUserId())
+
+    // 경매 등록 데이터 저장
+    public AuctionNonImageDto createAuction(AuctionByteImageDto auctionByteImageDto) {
+
+        Auction auction = Auction.builder()
+                .title(auctionByteImageDto.getTitle())
+                .name(auctionByteImageDto.getName())
+                .description(auctionByteImageDto.getDescription())
+                .quantity(auctionByteImageDto.getQuantity())
+                .startPrice(auctionByteImageDto.getStartPrice())
+                .createDate(LocalDateTime.now().toString())
+                .endDate(auctionByteImageDto.getEndDate())
+                .resisteredUserId(auctionByteImageDto.getResisteredUserId())
+                .closedAuction("NO")
                 .build();
 
-        auctionRepository.save(aution);
+        Auction savedAuction = auctionRepository.save(auction);
 
+        return new AuctionNonImageDto(savedAuction);
+    }
+
+    public AuctionByteImageDto findAuction(Long id) {
+
+        Auction auction = auctionRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 경매 정보가 존재하지 않거나 id값이 잘못되었습니다.."));
+        AuctionByteImageDto auctionDto = new AuctionByteImageDto(auction);
+        return auctionDto;
+    }
+
+    public AuctionByteImageDto closeUpdateAuction(Long id) {
+        Auction auction = auctionRepository.findById(id).orElseThrow(()-> new IllegalArgumentException("경매 정보가 존재하지 않습니다."));
+        auction.updateClosedAuction("YES");
+        auctionRepository.save(auction);
+        return new AuctionByteImageDto(auction);
     }
 }
-/*
-    private String title;
-    private String name;
-    private String description;
-    private long quantity;
-    private String startPrice;
-    private Timestamp createDate;
-    private Timestamp endDate;
-    private long resisteredUserId;
-    private long winningUserId;
-    private String winningUserComment;
- */

--- a/src/main/java/jungmae/auction/service/ImageService.java
+++ b/src/main/java/jungmae/auction/service/ImageService.java
@@ -1,0 +1,29 @@
+package jungmae.auction.service;
+
+import jungmae.auction.domain.Auction;
+import jungmae.auction.domain.Image;
+import jungmae.auction.domain.dto.AuctionByteImageDto;
+import jungmae.auction.domain.dto.AuctionImageUrlDto;
+import jungmae.auction.domain.dto.AuctionNonImageDto;
+import jungmae.auction.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final ImageRepository imageRepository;
+
+    public void saveAllImages(AuctionNonImageDto auctionNonImageDto, List<String> images) {
+
+        for (String img : images) {
+
+            Image image = new Image(img, auctionNonImageDto.toEntity());
+            imageRepository.save(image);
+            System.out.println("image = " + image + "   저장!!!");
+        }
+    }
+}

--- a/src/main/java/jungmae/auction/service/NaverCloudS3Service.java
+++ b/src/main/java/jungmae/auction/service/NaverCloudS3Service.java
@@ -1,0 +1,112 @@
+package jungmae.auction.service;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import jakarta.annotation.PostConstruct;
+import jungmae.auction.domain.Auction;
+import jungmae.auction.domain.Image;
+import jungmae.auction.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NaverCloudS3Service {
+
+    private AmazonS3 s3;
+    @Value("${naver.cloud.bucket-name}")
+    private String bucketName;
+    @Value("${naver.cloud.folder-name}")
+    private String folderName;
+    @Value("${naver.cloud.end-point}")
+    private String endPoint;
+    @Value("${naver.cloud.region}")
+    private String region;
+    @Value("${naver.cloud.access-key}")
+    private String accessKey;
+    @Value("${naver.cloud.secret-key}")
+    private String secretKey;
+//
+//    private final String endPoint = "https://kr.object.ncloudstorage.com";
+//    private final String regionName = "kr-standard";
+//    private final String accessKey = "ncp_iam_BPASKR4WEYRJj8XYvH2v";
+//    private final String secretKey = "ncp_iam_BPKSKRHte3xuxUlKxisE2GB74ueSFNLplf";
+
+    @PostConstruct
+    public void init() {
+        // AWS S3 클라이언트 초기화
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        this.s3 = AmazonS3ClientBuilder.standard()
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endPoint, region))
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+
+        // 버킷 생성
+        try {
+            if (!s3.doesBucketExistV2(bucketName)) {
+                s3.createBucket(bucketName);
+                System.out.format("Bucket %s has been created.\n", bucketName);
+            } else {
+                System.out.format("Bucket %s already exists.\n", bucketName);
+            }
+        } catch (AmazonS3Exception e) {
+            System.err.println("Error creating bucket: " + e.getMessage());
+        } catch (SdkClientException e) {
+            System.err.println("SDK Client error: " + e.getMessage());
+        }
+    }
+
+    // 경매 등록 데이터의 byte형식으로 되어있는 image를 클라우드 저장소에 저장 후 image값을 Stirng 형태의 저장소 url값으로 재정의 후 반환.
+    public List<String> uploadImages(byte[][] images) throws IOException {
+        List<String> urls = new ArrayList<>();
+
+        for (int i = 0; i < images.length; i++) {
+            System.out.println(i + " 번째 이미지 바이트 = " + images[i]);
+            if (images[i] == null || images[i].length == 0) {
+                continue; // 비어 있는 이미지는 건너뜀
+            }
+            String key = folderName + "image-" + System.currentTimeMillis() + "-" + i + ".jpg"; // 고유한 키 생성
+            String mimeType = "image/jpeg"; // 기본 MIME 타입 설정 (필요 시 동적으로 변경 가능)
+
+            // ByteArrayInputStream을 try-with-resources로 사용하여 자동으로 닫기
+            try (ByteArrayInputStream inputStream = new ByteArrayInputStream(images[i])) {
+                ObjectMetadata metadata = new ObjectMetadata();
+                metadata.setContentLength(images[i].length);
+                metadata.setContentType(mimeType); // MIME 타입 설정
+
+                // 이미지 업로드 요청
+                PutObjectRequest request = new PutObjectRequest(bucketName, key, inputStream, metadata);
+                s3.putObject(request); // 클라우드에 이미지 업로드
+
+                // 업로드 후 URL 생성
+                String url = String.format("https://%s.s3.kr.object.ncloudstorage.com/%s", bucketName, key);
+                urls.add(url); // URL 리스트에 추가
+            } catch (AmazonS3Exception e) {
+                e.printStackTrace(); // S3 관련 예외 처리
+                // 추가적인 로깅이나 사용자에게 피드백을 주는 코드 추가 가능
+            } catch (SdkClientException e) {
+                e.printStackTrace(); // SDK 관련 예외 처리
+                // 추가적인 로깅이나 사용자에게 피드백을 주는 코드 추가 가능
+            }
+
+
+        }
+
+        return urls; // 모든 URL 반환
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=auction

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+server:
+  port: 8080
+  servlet:
+    context-path: /
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/security?serverTimezone=Asia/Seoul
+    username: cos
+    password: cos1234
+
+  jpa:
+    hibernate:
+      ddl-auto: update #create update none
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    show-sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,12 @@ spring:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     show-sql: true
+
+naver:
+  cloud:
+    end-point: https://kr.object.ncloudstorage.com
+    access-key:
+    secret-key:
+    bucket-name: contest59
+    folder-name: auciton/
+    region: kr-standard


### PR DESCRIPTION
1. 클라이언트에서 경매 등록 관련 데이터를 AuctionByteImageDto로 가져온다 (바이트 형태로 된 이차배열 형식의 이미지값 포함.)
2. 위 Dto를 사용해 경매 정보 등록 후 디비에 등록된 auction데이터를 id값을 포함하여 AuctionNonImageDto에 할당
3. auctionByteImageDto의 이미지 바이트값들을 NCP Storagedml 버킷에 저장한 뒤 저장된 주소값들을 List형태로 반환.
4. 2번과 3번에서 만들어진 AuctionNonImageDto과 List<String> urls를 사용해 이미지테이블에 모두 저장.

----
리팩토링 고려사항.
Image와 관련된 로직 구성에 대해 검토가 필요하다. 팀원들과 상의해보는것으로 한다.